### PR TITLE
Updates EduAPI

### DIFF
--- a/concepts.include
+++ b/concepts.include
@@ -10,7 +10,7 @@ Note: initial list based on QualityLink glossary. Add specific terms needed for 
 :: a proof of the learning outcomes that a learner has acquired following a short learning experience. These learning outcomes have been assessed against transparent standards. [[CR-MC]]
 : <dfn>programme</dfn>
 :: collection of [=learning opportunities=]. Finalising a study programme usually leads to a degree (e.g. Bachelor degree, Master degree, etc.) or to another type of certificate, e.g. a [=micro-credential=], for a shorter programme. A programme is a "top-level" [=learning opportunity=] and has no parent.
-: <dfn>joint programme</dfn>
+: <dfn data-export>joint programme</dfn>
 :: an integrated curriculum coordinated and offered jointly by different [=higher education institutions=], and leading to double/multiple degrees or a joint degree. [[DEQAR]]
 : <dfn>education provider</dfn>
 :: any actor that provides degree programmes, micro-credentials or other [=learning opportunities=]. This may include [=higher education institutions=] as well as [=other providers=], including employers, companies, social partners, NGOs, public authorities and others. [[DEQAR]]
@@ -20,5 +20,5 @@ Note: initial list based on QualityLink glossary. Add specific terms needed for 
 :: an entity that provides learning opportunities, but that does not have officially-recognised authority to award degrees or other formally recognised qualifications.
 : <dfn>data provider</dfn>
 :: an entity providing data on [=learning opportunities=]. This can be an [=education provider=] providing data on its own learning opportunities or another organisation providing data on various [=education providers=].
-: <dfn>aggregator</dfn>
+: <dfn data-export>aggregator</dfn>
 :: any service that harvests data from different [=data providers=], matches and compiles the data into one single dataset. For example, the aggregator service developed within the QualityLink project.

--- a/data_exchange.bs
+++ b/data_exchange.bs
@@ -183,7 +183,73 @@ path: the URL of the OOAPI root
 Edu-API {#edu-api}
 -------
 
-Note: similar structure as for OOAPI
+[=Education providers=] can expose data on their learning opportunities using the Edu-API specification [[!Edu-API]], a RESTful API standard maintained by 1EdTech. 
+This method delivers JSON-formatted responses and supports real-time querying of educational data, such as courses and programs, making it suitable for dynamic aggregation scenarios.
+
+The [=aggregator=] may use the following endpoints to acquire data (non-exhaustive list, based on Edu-API Core):
+
+- `GET /courses` - Retrieve a list of courses.
+- `GET /courses/{courseId}` - Retrieve details of a specific course.
+- `GET /programs` - Retrieve a list of programs.
+- `GET /programs/{programId}` - Retrieve details of a specific program.
+
+Additional endpoints (e.g., for offerings or components) may be supported depending on the provider’s implementation.
+
+### Required Fields ### {#edu-api-required}
+
+The Edu-API specification defines a core set of fields for [=learning opportunities=], aligned with its *Learning Resource Core* profile. At a minimum, [=data providers=] must include:
+
+- `id`: Unique identifier for the learning opportunity.
+- `title`: Name or title of the course or program.
+- `description`: Brief description of the learning opportunity.
+- `type`: Type of learning opportunity (e.g., "Course", "Program").
+
+Additional fields (e.g., `credits`, `learningOutcomes`) are recommended where applicable to align with the European Learning Model [[!ELM]] and QualityLink goals. Providers should refer to 
+the Edu-API *Learning Resource Core* bindings for full details.
+
+### Incremental Updates ### {#edu-api-incremental}
+
+The [[!Edu-API]] specification includes a `dateLastModified` property in resource responses (e.g., for courses and programs), indicating the last modification date in ISO 8601 format. 
+This property enables tracking changes to individual resources and can be combined with the `filter` parameter on collections like `GET /courses` or `GET /programs` to support efficient 
+aggregation, providing patterns for both initial bulk loads and delta updates, [=data providers=] and [=aggregators=] should follow this choreography where possible:
+
+- **Initial or Bulk Load**: The [=aggregator=] makes a series of "get all" requests (e.g., `GET /courses`, `GET /programs`) to retrieve all resources needed, establishing a baseline dataset. The `dateLastModified` value for each resource should be recorded for subsequent delta updates.
+
+- **Delta or True-Up**: The [=aggregator=] repeats the "get all" requests, ideally using a filter on `dateLastModified` (e.g., `GET /courses?modifiedAfter=2025-03-01T00:00:00Z`) to retrieve only resources modified since the last sync. If this filter is not supported, the [=aggregator=] must fetch the full collection and compare `dateLastModified` values locally against the last sync timestamp.
+
+The QualityLink [=aggregator=] may use the `dateLastModified` value from previous responses to determine which resources have changed since the last harvest.
+
+### Metadata ### {#edu-api-metadata}
+
+[=Data providers=] must provide the following metadata in their manifest file for this method:
+
+<pre class=simpledef>
+type: `edu-api`
+path: The URL of the Edu-API root (e.g., `https://provider.example.edu/edu-api/v1/`)
+version: The Edu-API version implemented (e.g., `1.0`)
+</pre>
+
+### Authentication with OAuth 2.0 ### {#edu-api-oauth}
+
+Edu-API mandates the use of OAuth 2.0 for securing API endpoints, ensuring that only authorized [=aggregators=] (e.g., the QualityLink aggregator) can access protected data. [=Data providers=] must implement OAuth 2.0 as follows:
+
+- **Grant Type**: Support the *Client Credentials Grant* (per [[!RFC6749]], Section 4.4) for machine-to-machine authentication, suitable for aggregator access without user interaction. 
+- **Token Endpoint**: Provide a dedicated OAuth 2.0 token endpoint (e.g., `https://provider.example.edu/oauth/token`) where the [=aggregator=] can obtain an access token.
+- **Scopes**: Define scopes to limit access (e.g., `http://purl.1edtech.org/spec/eduapi/v1p0/scope/core.readonly` for read-only access to [=learning opportunity=] data).
+- **Access Token**: The [=aggregator=] must include a valid OAuth 2.0 Bearer token in the `Authorization` header of each request (e.g., `Authorization: Bearer <token>`).
+
+[=Data providers=] should:
+
+- Issue access tokens with a reasonable expiration time (e.g., 1 hour) and support refresh tokens if long-term access is needed.
+- Validate tokens server-side per [[!RFC6750]] (Bearer Token Usage).
+- Optionally align with the additional access control mechanisms in [[#access-control]] (e.g., IP restrictions, TLS client certificates, or HTTP headers) to further secure the data exchange process.
+
+The QualityLink [=aggregator=] must:
+
+- Support OAuth 2.0 Client Credentials Grant as a minimum.
+- Register with the [=data provider=] to obtain client credentials (`client_id` and `client_secret`).
+- Handle token expiration and renewal gracefully.
+
 
 OCCAPI {#occapi}
 ------
@@ -203,6 +269,8 @@ Currently all transport methods operate over HTTP. Hence the following access co
 A [=data provider=] may choose one of the strategies if they wish to control access to their data, but no access control is required.
 
 An [=aggregator=] should support all formats described.
+
+Note:  The exchange of access credentials for each of these options (certificates, trusted IPs, or client/secrets) is an out-of-band activity to be agreed between the [=aggregator=] and [=data providers=] during an onboarding/ discovery process.
 
 Based on IP address {#access-control-ip}
 -------------------
@@ -225,10 +293,20 @@ The [=data provider=] may request that the [=aggregator=] include a specific HTT
 
 Note: this option requires the data provider to have an account in the QualityLink aggregator/data source registry to manage this. To be described further.
 
+OAuth 2.0 {#access-control-oauth}
+------------------
+
+A [=data provider=] may secure their endpoints using OAuth 2.0, requiring the [=aggregator=] to authenticate via an access token. This method is mandatory for [[!Edu-API]] (see [[#edu-api-oauth]]) and recommended for other methods.
+
+- The [=data provider=] must provide a token endpoint and support the *Client Credentials Grant* [[!RFC6749]] as a minimum.
+- The [=aggregator=] must include a Bearer token in the `Authorization` header (per [[!RFC6750]]).
+- Scopes should be defined to restrict access (e.g., `read:learning-opportunities`).
+
+**Note**: See [[#edu-api-oauth]] for detailed implementation requirements.
+
 Security Considerations {#security}
 =======================
 
 The previous chapter describes how [=data providers=] can implement access control to their exposed data.
 
 This specification is about exchange of data on [=learning opportunities=], which is generally meant to be public. [=Data providers=] should not expose any data through the methods described herein that is not meant to be public, especially no personal data.
-


### PR DESCRIPTION
Includes:
- Edu-API updates
- Additional information for OAuth 2. (required by Edu-API)
- Statement that the exchange of chosen access-control mechanisms (trusted-ip, certs, client/ secrets) is an out-of-band activity
- minor fix to bikeshed warnings on data definition exports.